### PR TITLE
[BE] refactor #63: getPopularityRanking() 메서드 수정

### DIFF
--- a/be/src/main/java/com/codesquad/kiosk/controller/MenuController.java
+++ b/be/src/main/java/com/codesquad/kiosk/controller/MenuController.java
@@ -28,7 +28,7 @@ public class MenuController {
     }
 
     @ApiOperation(value = "개별 메뉴 조회")
-    @GetMapping("api/carts/{menuId}")
+    @GetMapping("api/menuInfo/{menuId}")
     public ResponseEntity<MenuDetailDto> getMenuDetail(@PathVariable Integer menuId){
         try {
             MenuDetailDto menuDetailDto = menuService.getMenuDetail(menuId);

--- a/be/src/main/java/com/codesquad/kiosk/repository/MenuRepository.java
+++ b/be/src/main/java/com/codesquad/kiosk/repository/MenuRepository.java
@@ -1,19 +1,20 @@
 package com.codesquad.kiosk.repository;
 
-import com.codesquad.kiosk.dto.MenuDetailDto;
-import com.codesquad.kiosk.dto.OptionCategoryDto;
-import lombok.RequiredArgsConstructor;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
-import java.util.*;
 import com.codesquad.kiosk.domain.Menu;
 import com.codesquad.kiosk.domain.OrderMenu;
+import com.codesquad.kiosk.dto.MenuDetailDto;
+import com.codesquad.kiosk.dto.OptionCategoryDto;
+
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -34,7 +35,7 @@ public class MenuRepository {
 		return namedParameterJdbcTemplate.query(sql, param, menuRowMapper());
 	}
 
-	public List<OrderMenu> getPopularityRanking(Integer categoryId) {
+	public Optional<OrderMenu> getPopularityRanking(Integer categoryId) {
 		String sql = "SELECT MENU_ID, SUM(QUANTITY) AS SUM_QUANTITY FROM ORDER_MENU "
 			+ "INNER JOIN MENU ON ORDER_MENU.MENU_ID = MENU.ID "
 			+ "INNER JOIN ORDERS ON ORDER_MENU.ORDER_ID = ORDERS.ID "
@@ -44,7 +45,7 @@ public class MenuRepository {
 		SqlParameterSource param = new MapSqlParameterSource()
 			.addValue("categoryId", categoryId)
 			.addValue("now", LocalDate.now());
-		return namedParameterJdbcTemplate.query(sql, param, orderMenuRowMapper());
+		return namedParameterJdbcTemplate.query(sql, param, orderMenuRowMapper()).stream().findFirst();
 	}
 
 	private RowMapper<Menu> menuRowMapper() {

--- a/be/src/main/java/com/codesquad/kiosk/service/MenuService.java
+++ b/be/src/main/java/com/codesquad/kiosk/service/MenuService.java
@@ -1,22 +1,25 @@
 package com.codesquad.kiosk.service;
 
-import com.codesquad.kiosk.domain.Menu;
-import com.codesquad.kiosk.dto.CategoryResponseDto;
-import com.codesquad.kiosk.dto.MenuDetailDto;
-import com.codesquad.kiosk.dto.OptionCategoryDto;
-import com.codesquad.kiosk.dto.MenusByCategoryResponseDto;
-import com.codesquad.kiosk.repository.MenuRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.codesquad.kiosk.domain.Menu;
+import com.codesquad.kiosk.domain.OrderMenu;
+import com.codesquad.kiosk.dto.CategoryResponseDto;
+import com.codesquad.kiosk.dto.MenuDetailDto;
+import com.codesquad.kiosk.dto.MenusByCategoryResponseDto;
+import com.codesquad.kiosk.dto.OptionCategoryDto;
+import com.codesquad.kiosk.repository.MenuRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MenuService {
 
     private final MenuRepository menuRepository;
-	  private final static int FIRST = 0;
 
     public List<CategoryResponseDto> getCategories() {
         List<String> categories = menuRepository.getCategoryList();
@@ -27,7 +30,11 @@ public class MenuService {
 
 	  public List<MenusByCategoryResponseDto> getMenusByCategory(Integer categoryId) {
 		List<Menu> menuList = menuRepository.getMenuList(categoryId);
-		int menuId = menuRepository.getPopularityRanking(categoryId).get(FIRST).getMenuId();
+		int menuId = menuRepository.getPopularityRanking(categoryId)
+			.orElse(OrderMenu.builder()
+				.menuId(0)
+				.build())
+			.getMenuId();
 		List<MenusByCategoryResponseDto> menus = menuList.stream()
 			.map(menu -> MenusByCategoryResponseDto.builder()
 				.name(menu.getName())
@@ -36,7 +43,11 @@ public class MenuService {
 				.img(menu.getImg())
 				.build())
 			.collect(Collectors.toList());
-		menus.get(menuId - 1).setPopular();
+		  for (MenusByCategoryResponseDto menu : menus) {
+			  if (menu.getMenuId() == menuId) {
+				  menu.setPopular();
+			  }
+		  }
 		return menus;
 	}
   


### PR DESCRIPTION
당일 판매량이 없을 경우 테이블 값이 아예 없어 오류가 발생. Optional을 사용하여 첫번째 값만 받아오고 null일 경우 menuId가 0이 되도록 하여 인기 스티커가 아무곳에도 붙지 않도록 수정.